### PR TITLE
Add missing block start keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-matlab-octave",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "MATLAB grammar support from official Mathworks bundle (used on Github.com). Octave support converted from TextMate.",
   "keywords": [
     "MATLAB",

--- a/settings/language-matlab-octave.cson
+++ b/settings/language-matlab-octave.cson
@@ -10,6 +10,8 @@
              |for|parfor|while
              |try|catch
              |unwind_protect
+             |properties|methods
+             |enumeration|events|arguments
       	)\\b
     '''
     decreaseIndentPattern: "^\\s*\\b(end\\w*|catch|else|elseif|case|otherwise)\\b"


### PR DESCRIPTION
Handle classdef-releated items like `properties, methods, enumeration, events`.